### PR TITLE
fixes #23

### DIFF
--- a/ABPFilterParser.cpp
+++ b/ABPFilterParser.cpp
@@ -149,7 +149,7 @@ bool getFingerprint(char *buffer, const Filter &f) {
 }
 
 // Separator chars are one of: :?/=^;
-char separatorBuffer[32] = { 0, 0, 0, 0, 16, -128, 0, -92, 0, 0, 0, 64 };
+signed char separatorBuffer[32] = { 0, 0, 0, 0, 16, -128, 0, -92, 0, 0, 0, 64 };
 bool isSeparatorChar(char c) {
   return !!(separatorBuffer[(unsigned char)c / 8] & 1 << (unsigned char)c % 8);
 }


### PR DESCRIPTION
On ARM architecture, this negative numbers were causing a compiling error "error: narrowing conversion of '-92' from 'int' to 'char' inside { } [-Wnarrowing]"