### PR TITLE
Allow Embedded Tweets By De-Listing platform.twitter.com

### DIFF
--- a/test/data/easylist.txt
+++ b/test/data/easylist.txt
@@ -35858,7 +35858,7 @@ coingamez.com,mangaumaru.com,milfzr.com,pencurimovie.cc#@#div[id^="div-gpt-ad-"]
 |https://$script,third-party,xmlhttprequest,domain=1337x.to
 ! watchseries.li
 @@||connect.facebook.net^$script,domain=watchseries.li
-@@||platform.twitter.com^$script,domain=watchseries.li
+
 |http://$script,third-party,domain=watchseries.li
 |https://$script,third-party,domain=watchseries.li
 ! briskfile.com


### PR DESCRIPTION
In https://github.com/brave/browser-laptop/issues/1208 -- It is requested that Brave Allow Embedded Tweets. Removing platform.twitter.com from easylist will allow them to be displayed. Currently In 0.8.3 Bravery -> Allow Ads will allow the tweet to be displayed.